### PR TITLE
NEWS, test fixes for check_duplicates PR fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 Changes in this release:
 
-* Add {glue} as package dependency. This helps to elaborate error messages (@chguiterman, #196)
+* Add `glue` as package dependency. This helps to elaborate error messages (@chguiterman, #196)
+
 * Updated error checking for `+` operator, specifically targeting duplicated series names. (@chguiterman, PR #196)
 
 
@@ -11,10 +12,8 @@ Changes in this release:
 Changes in this release:
 
 * Update DOI badge and support documentation on main website and README. (@chguiterman, PR #182).
-* Updated error checking for `+` operator, specifically targeting duplicated series names (#186)
-* Test for new ks.test behavior in r-devel. (@brews, PR #191)
 
-* Update DOI badge and support documentation on main website and README. (@chguiterman, PR #182)
+* Test for new ks.test behavior in r-devel. (@brews, PR #191)
 
 
 # burnr v0.6.0

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -170,22 +170,24 @@ test_that("+.fhx on FHX objects", {
     series = factor(series2),
     rec_type = rt2
   )
-  test_fhx3 <- rbind(test_fhx1, test_fhx2)
-  test_fhx4 <- test_fhx1 + test_fhx2
+
+  test_fhx3 <- test_fhx1 + test_fhx2
 
   expect_equal(test_fhx3$year, c(year1, year2))
   expect_equal(test_fhx3$series, factor(c(series1, series2)))
   expect_equal(test_fhx3$rec_type, make_rec_type(c(rt1, rt2)))
-
-  checked <- burnr:::check_duplicates(test_fhx1, test_fhx2)
-  expect_equal(test_fhx3, test_fhx1 + test_fhx2)
-
-  expect_error(
-    burnr:::check_duplicates(test_fhx1, test_fhx1)
-  )
-  expect_error(test_fhx1 + test_fhx1)
 })
 
+test_that("+.fhx throws error when fhx obj has duplicates", {
+  test_fhx <- fhx(
+    year = c(1850, 2010),
+    series = factor(c("a", "a")),
+    rec_type = c(
+      "pith_year", "bark_year"
+    )
+  )
+  expect_error(test_fhx + test_fhx, regexp = "duplicate series", fixed = TRUE)
+})
 
 test_that("as_fhx works on data.frame input", {
   yrs <- c(1850, 2010)


### PR DESCRIPTION
Proposed changes to resolve remaining issues discussed in https://github.com/ltrr-arizona-edu/burnr/pull/196.

Specifically, this

- Cleans up NEWS.md, removing duplicate entries and cleaning up formatting.
- Cleans up test changes from the PR, simplifying input test data setup, and creating a separate test to ensure that `+.fhx` throws a thoughtful error when duplicates are present in the input data.